### PR TITLE
chore: update nodemon to v3.1.10 and remove pesona-ciamis-backend sub…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "mysql2": "^3.6.5"
       },
       "devDependencies": {
-        "nodemon": "^3.0.2"
+        "nodemon": "^3.1.10"
       }
     },
     "node_modules/@mapbox/node-pre-gyp": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "mysql2": "^3.6.5"
   },
   "devDependencies": {
-    "nodemon": "^3.0.2"
+    "nodemon": "^3.1.10"
   }
 }


### PR DESCRIPTION
…module

Update nodemon dependency to latest patch version for bug fixes and improvements. Remove unused pesona-ciamis-backend git submodule as it's no longer needed.